### PR TITLE
Feat/calendar rei timeoff v0.3.1 dev

### DIFF
--- a/db.py
+++ b/db.py
@@ -166,6 +166,12 @@ def init_db() -> None:
             ("Admin", "User", "admin", generate_password_hash("changeme"), "admin", 1),
         )
 
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_jobs_start ON jobs(start_date);")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_jobs_end ON jobs(end_date);")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_timeoff_start ON time_off(start_date);")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_timeoff_end ON time_off(end_date);")
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_locks_date ON locks(date);")
+
     conn.commit()
     conn.close()
     logger.info("Database ready.")

--- a/routes/calendar_routes.py
+++ b/routes/calendar_routes.py
@@ -10,6 +10,7 @@ Notes:
     Uses state code ``VA`` for holidays via ``holidays_for_month``.
 """
 
+from collections import defaultdict
 from calendar import Calendar, month_name, monthrange
 from datetime import date, datetime, timedelta
 
@@ -62,34 +63,15 @@ def _expand_multi_day(sd_str: str, ed_str: str | None):
 
 @calendar_bp.route("/", endpoint="index")
 def index():
-    """Render the month (calendar) view.
-
-    Query args:
-        month (int, optional): 1-12; defaults to current month.
-        year (int, optional): Four-digit year; defaults to current year.
-
-    Behavior:
-        - Computes month boundaries and week grid.
-        - Loads day locks and jobs spanning the month (inclusive).
-        - Expands multi-day jobs to each date for rendering.
-        - Loads technician time off and expands to each date.
-        - Computes holiday map for the month (state ``"VA"``).
-        - Passes type abbreviations to the template.
-
-    Returns:
-        Response: Rendered ``index.html`` with calendar context.
-    """
     today = date.today()
     month = request.args.get("month", type=int, default=today.month)
     year = request.args.get("year", type=int, default=today.year)
 
-    month_start = date(year, month, 1)
-    month_end = date(year, month, monthrange(year, month)[1])
-
-    month_start_s = month_start.isoformat()
-    month_end_s = month_end.isoformat()
-
-    weeks = _month_weeks(year, month)
+    # build week grid
+    weeks = _month_weeks(year, month, firstweekday=6)
+    grid_start = weeks[0][0]
+    grid_end = weeks[-1][-1]
+    grid_start_s, grid_end_s = grid_start.isoformat(), grid_end.isoformat()
 
     prev_month, prev_year = (12, year - 1) if month == 1 else (month - 1, year)
     next_month, next_year = (1, year + 1) if month == 12 else (month + 1, year)
@@ -97,11 +79,11 @@ def index():
     conn = get_database()
     cur = conn.cursor()
 
-    cur.execute("SELECT date FROM locks")
+    cur.execute(
+        "SELECT date FROM locks WHERE date BETWEEN ? AND ?",
+        (grid_start_s, grid_end_s),
+    )
     locks = {row["date"] for row in cur.fetchall()}
-
-    jobs_by_date = {}
-    time_off_by_date = {}
 
     cur.execute(
         """
@@ -128,47 +110,71 @@ def index():
             END AS technician_label
         FROM jobs j
         LEFT JOIN technicians t ON t.id = j.technician_id
-        WHERE j.start_date <= ?
-            AND (j.end_date IS NULL OR j.end_date >= ?);
+        WHERE date(j.start_date) <= date(:grid_end)
+          AND date(COALESCE(j.end_date, j.start_date)) >= date(:grid_start)
         """,
-        (month_end_s, month_start_s),
+        {"grid_start": grid_start_s, "grid_end": grid_end_s},
     )
 
+    jobs_by_date: dict[str, list] = defaultdict(list)
     for job in cur.fetchall():
-        for d in _expand_multi_day(job["start_date"], job["end_date"]):
-            jobs_by_date.setdefault(d.isoformat(), []).append(job)
+        sd = datetime.fromisoformat(job["start_date"]).date()
+        ed = datetime.fromisoformat(job["end_date"]).date() if job["end_date"] else sd
+        start = sd if sd >= grid_start else grid_start
+        end = ed if ed <= grid_end else grid_end
+        d = start
+        while d <= end:
+            jobs_by_date[d.isoformat()].append(job)
+            d += timedelta(days=1)
 
     cur.execute(
         """
-        SELECT toff.start_date, toff.end_date, tech.name AS technician_name
-        FROM time_off toff
-        JOIN technicians tech ON tech.id = toff.technician_id
-        """
+        SELECT
+          toff.start_date,
+          toff.end_date,
+          tech.name AS technician_name
+        FROM time_off AS toff
+        JOIN technicians AS tech ON tech.id = toff.technician_id
+        WHERE date(toff.start_date) <= date(:grid_end)
+          AND date(COALESCE(toff.end_date, toff.start_date)) >= date(:grid_start)
+        """,
+        {"grid_start": grid_start_s, "grid_end": grid_end_s},
     )
-    time_off_by_date: dict[str, list[str]] = {}
+
+    time_off_by_date: dict[str, list[str]] = defaultdict(list)
     for row in cur.fetchall():
-        for d in _expand_multi_day(row["start_date"], row["end_date"]):
-            time_off_by_date.setdefault(d.isoformat(), []).append(
-                row["technician_name"]
-            )
+        sd = datetime.fromisoformat(row["start_date"]).date()
+        ed = datetime.fromisoformat(row["end_date"]).date() if row["end_date"] else sd
+        start = sd if sd >= grid_start else grid_start
+        end = ed if ed <= grid_end else grid_end
+        d = start
+        while d <= end:
+            time_off_by_date[d.isoformat()].append(row["technician_name"])
+            d += timedelta(days=1)
 
     conn.close()
 
-    holidays = {}
-
-    TYPE_ABBR = {
-        "fumigation": "F",
-        "insulation": "I",
-        "exclusion": "EX",
-        "rei": "REIs",
-        "borate": "B",
-        "bird work": "BW",
-        "poly": "P",
-        "power spray": "PS",
-    }
-
     STATE_CODE = "VA"
     holidays_map = holidays_for_month(year, month, state=STATE_CODE)
+
+    TYPE_ABBR = {
+        "termite": "T",
+        "borate": "BOR",
+        "pretreat": "PT",
+        "retreat": "RT",
+        "bird work": "BRD",
+        "power spray": "PS",
+        "fumigation": "FUME",
+        "insulation": "INSU",
+        "exclusion": "EXC",
+        "rei": "REIs",
+        "reis": "REIs",
+        "pest control special service": "PCSS",
+        "vapor barrier": "VAPR",
+        "shop work": "SHOP",
+        "misc": "MISC",
+        "miscellaneous": "MISC",
+    }
 
     return render_template(
         "index.html",
@@ -177,8 +183,8 @@ def index():
         year=year,
         month_name=month_name[month],
         prev_month=prev_month,
-        prev_year=prev_year,
         next_month=next_month,
+        prev_year=prev_year,
         next_year=next_year,
         locks=locks,
         jobs_by_date=jobs_by_date,
@@ -187,6 +193,135 @@ def index():
         type_abbr=TYPE_ABBR,
         holidays=holidays_map,
     )
+
+
+# @calendar_bp.route("/", endpoint="index")
+# def index():
+#     """Render the month (calendar) view.
+
+#     Query args:
+#         month (int, optional): 1-12; defaults to current month.
+#         year (int, optional): Four-digit year; defaults to current year.
+
+#     Behavior:
+#         - Computes month boundaries and week grid.
+#         - Loads day locks and jobs spanning the month (inclusive).
+#         - Expands multi-day jobs to each date for rendering.
+#         - Loads technician time off and expands to each date.
+#         - Computes holiday map for the month (state ``"VA"``).
+#         - Passes type abbreviations to the template.
+
+#     Returns:
+#         Response: Rendered ``index.html`` with calendar context.
+#     """
+#     today = date.today()
+#     month = request.args.get("month", type=int, default=today.month)
+#     year = request.args.get("year", type=int, default=today.year)
+
+#     month_start = date(year, month, 1)
+#     month_end = date(year, month, monthrange(year, month)[1])
+
+#     month_start_s = month_start.isoformat()
+#     month_end_s = month_end.isoformat()
+
+#     weeks = _month_weeks(year, month)
+
+#     prev_month, prev_year = (12, year - 1) if month == 1 else (month - 1, year)
+#     next_month, next_year = (1, year + 1) if month == 12 else (month + 1, year)
+
+#     conn = get_database()
+#     cur = conn.cursor()
+
+#     cur.execute("SELECT date FROM locks")
+#     locks = {row["date"] for row in cur.fetchall()}
+
+#     jobs_by_date = {}
+#     time_off_by_date = {}
+
+#     cur.execute(
+#         """
+#         SELECT
+#             j.id,
+#             j.title,
+#             j.job_type AS type,
+#             j.price,
+#             j.start_date,
+#             j.end_date,
+#             j.start_time,
+#             j.end_time,
+#             j.time_range,
+#             j.rei_quantity AS rei_quantity,
+#             j.rei_zip AS rei_zip,
+#             j.rei_city_name AS rei_city_name,
+#             j.technician_id,
+#             j.two_man,
+#             t.name AS technician_name,
+#             CASE
+#                 WHEN j.two_man = 1 THEN 'Two Man'
+#                 WHEN t.name IS NOT NULL THEN t.name
+#                 ELSE ''
+#             END AS technician_label
+#         FROM jobs j
+#         LEFT JOIN technicians t ON t.id = j.technician_id
+#         WHERE j.start_date <= ?
+#             AND (j.end_date IS NULL OR j.end_date >= ?);
+#         """,
+#         (month_end_s, month_start_s),
+#     )
+
+#     for job in cur.fetchall():
+#         for d in _expand_multi_day(job["start_date"], job["end_date"]):
+#             jobs_by_date.setdefault(d.isoformat(), []).append(job)
+
+#     cur.execute(
+#         """
+#         SELECT toff.start_date, toff.end_date, tech.name AS technician_name
+#         FROM time_off toff
+#         JOIN technicians tech ON tech.id = toff.technician_id
+#         """
+#     )
+#     time_off_by_date: dict[str, list[str]] = {}
+#     for row in cur.fetchall():
+#         for d in _expand_multi_day(row["start_date"], row["end_date"]):
+#             time_off_by_date.setdefault(d.isoformat(), []).append(
+#                 row["technician_name"]
+#             )
+
+#     conn.close()
+
+#     holidays = {}
+
+#     TYPE_ABBR = {
+#         "fumigation": "F",
+#         "insulation": "I",
+#         "exclusion": "EX",
+#         "rei": "REIs",
+#         "borate": "B",
+#         "bird work": "BW",
+#         "poly": "P",
+#         "power spray": "PS",
+#     }
+
+#     STATE_CODE = "VA"
+#     holidays_map = holidays_for_month(year, month, state=STATE_CODE)
+
+#     return render_template(
+#         "index.html",
+#         weeks=weeks,
+#         month=month,
+#         year=year,
+#         month_name=month_name[month],
+#         prev_month=prev_month,
+#         prev_year=prev_year,
+#         next_month=next_month,
+#         next_year=next_year,
+#         locks=locks,
+#         jobs_by_date=jobs_by_date,
+#         time_off_by_date=time_off_by_date,
+#         today=today,
+#         type_abbr=TYPE_ABBR,
+#         holidays=holidays_map,
+#     )
 
 
 @calendar_bp.route("/day/<selected_date>", endpoint="day_view")
@@ -221,6 +356,22 @@ def day_view(selected_date: str):
 
     cur.execute(
         """
+    SELECT toff.id,
+        toff.technician_id,
+        tech.name AS tech_name,
+        toff.reason
+    FROM time_off AS toff
+    LEFT JOIN technicians AS tech ON tech.id = toff.technician_id
+    WHERE date(:sel) BETWEEN date(toff.start_date)
+                        AND date(COALESCE(toff.end_date, toff.start_date))
+    ORDER BY tech.name
+    """,
+        {"sel": selected_date},
+    )
+    time_off = cur.fetchall()
+
+    cur.execute(
+        """
         SELECT
             j.*,
             j.job_type AS type,
@@ -246,7 +397,9 @@ def day_view(selected_date: str):
     jobs = cur.fetchall()
 
     conn.close()
-    return render_template("day.html", selected_date=dt, locked=locked, jobs=jobs)
+    return render_template(
+        "day.html", selected_date=dt, locked=locked, jobs=jobs, time_off=time_off
+    )
 
 
 @calendar_bp.route("/timeoff/add", methods=["GET", "POST"], endpoint="add_time_off")
@@ -306,9 +459,8 @@ def toggle_lock():
         flash("No date provided.", "error")
         return redirect(url_for("calendar.index"))
 
-    user = session.get("user")
-    user_id = user["id"] if isinstance(user, dict) and "id" in user else None
-
+    user = session.get("user") or {}
+    user_id = user.get("user_id") or user.get("id")
     conn = get_database()
     cur = conn.cursor()
 

--- a/templates/_job_fields.html
+++ b/templates/_job_fields.html
@@ -1,181 +1,227 @@
 <!-- Schedule -->
 <div class="form-section">
-    <h3 class="section-heading">Schedule</h3>
+  <h3 class="section-heading">Schedule</h3>
 
-    {% if not hide_date_fields %}
-        <div class="form-group">
-            <label for="start_date">Start Date</label>
-            <input type="date" name="start_date" id="start_date" required>
-        </div>
-        <div class="form-group">
-            <label for="end_date">End Date (optional)</label>
-            <input type="date" name="end_date" id="end_date">
-        </div>
-    {% else %}
-        <div class="form-group">
-            <label for="start_date">Start Date</label>
-            <input type="date" name="start_date" id="start_date" required value="{{ date.isoformat() }}">
-        </div>
-        <div class="form-group">
-            <label for="end_date">End Date</label>
-            <input type="date" name="end_date" id="end_date" required value="{{ date.isoformat() }}">
-        </div>
-    {% endif %}
-        <div class="form-group">
-            <label for="start_time">Start Time (optional)</label>
-            <input type="time" name="start_time" id="start_time" value="{{ (job.start_time if job is defined else '') }}"
-        </div>
-        <div class="form-group">
-            <label for="end_time">End Time (opional)</label>
-            <input type="time" name="end_time" id="end_time" value="{{ (job.end_time if job is defined else '') }}">
-        </div>
+  {% if not hide_date_fields %}
+    <div class="form-group">
+      <label for="start_date">Start Date</label>
+      <input type="date" name="start_date" id="start_date" required>
+    </div>
+    <div class="form-group">
+      <label for="end_date">End Date (optional)</label>
+      <input type="date" name="end_date" id="end_date">
+    </div>
+  {% else %}
+    <div class="form-group">
+      <label for="start_date">Start Date</label>
+      <input type="date" name="start_date" id="start_date" required value="{{ date.isoformat() }}">
+    </div>
+    <div class="form-group">
+      <label for="end_date">End Date</label>
+      <input type="date" name="end_date" id="end_date" required value="{{ date.isoformat() }}">
+    </div>
+  {% endif %}
 
-        <div class="form-group">
-            <label for="technician_id">Assign Technician</label>
-            <select id="technician_id" name="technician_id">
-                <option value="">-- Unassigned --</option>
-                {% for t in technicians %}
-                    <option value="{{ t.id }}"> {{ t.name }}</option>
-                {% endfor %}
-                <option value="__BOTH__">Two Man</option>
-            </select>
-        </div>
+  <div class="form-group">
+    <label for="start_time">Start Time (optional)</label>
+    <input type="time" name="start_time" id="start_time" value="{{ (job.start_time if job is defined else '') }}">
+  </div>
+  <div class="form-group">
+    <label for="end_time">End Time (optional)</label>
+    <input type="time" name="end_time" id="end_time" value="{{ (job.end_time if job is defined else '') }}">
+  </div>
+
+  <div class="form-group">
+    <label for="technician_id">Assign Technician</label>
+    <select id="technician_id" name="technician_id">
+      <option value="">-- Unassigned --</option>
+      {% for t in technicians %}
+        <option value="{{ t.id }}" {% if job is defined and job.technician_id == t.id %}selected{% endif %}>{{ t.name }}</option>
+      {% endfor %}
+      <option value="__BOTH__" {% if job is defined and job.two_man %}selected{% endif %}>Two-Man</option>
+    </select>
+  </div>
 </div>
 
 <!-- Job Details -->
 <div class="form-section">
-    <h3 class="section-heading">Job Details</h3>
+  <h3 class="section-heading">Job Details</h3>
 
-    <div class="form-group">
-        <label for="type">Type:</label>
-        <select name="job_type" id="job_type" onchange="handleTypeChange(this)">
-            <option value="termite">Termite</option>
-            <option value="borate">Borate</option>
-            <option value="pretreat">Pretreat</option>
-            <option value="retreat">Retreat</option>
-            <option value="bird work">Bird Work</option>
-            <option value="reis">REIs</option>
-            <option value="power spray">Power Spray</option>
-            <option value="fumigation">Fumigation</option>
-            <option value="insulation">Insulation</option>
-            <option value="exclusion">Exclusion</option>
-            <option value="custom">Custom...</option>
-        </select>
+  <div class="form-group">
+    <label for="job_type">Type:</label>
+    <select name="job_type" id="job_type">
+      {% set jt = (job.job_type|lower if job is defined and job.job_type else '') %}
+      <option value="termite"      {% if jt=='termite' %}selected{% endif %}>Termite</option>
+      <option value="borate"       {% if jt=='borate' %}selected{% endif %}>Borate</option>
+      <option value="pretreat"     {% if jt=='pretreat' %}selected{% endif %}>Pretreat</option>
+      <option value="retreat"      {% if jt=='retreat' %}selected{% endif %}>Retreat</option>
+      <option value="bird work"    {% if jt=='bird work' %}selected{% endif %}>Bird Work</option>
+      <option value="rei"          {% if jt=='rei' %}selected{% endif %}>REIs</option> <!-- fixed value -->
+      <option value="power spray"  {% if jt=='power spray' %}selected{% endif %}>Power Spray</option>
+      <option value="fumigation"   {% if jt=='fumigation' %}selected{% endif %}>Fumigation</option>
+      <option value="insulation"   {% if jt=='insulation' %}selected{% endif %}>Insulation</option>
+      <option value="exclusion"    {% if jt=='exclusion' %}selected{% endif %}>Exclusion</option>
+      <option value="custom"       {% if jt=='custom' %}selected{% endif %}>Custom...</option>
+    </select>
+  </div>
+
+  <div id="generic-job-fields">
+    <div class="form-group" id="job-name-wrapper">
+      <label for="title">Job Name:</label>
+      <input type="text" name="title" id="title-field" value="{{ (job.title if job is defined else '') }}">
     </div>
 
-    <div id="generic-job-fields">
-        <div class="form-group" id="job-name-wrapper">
-            <label for="title">Job Name:</label>
-            <input type="text" name="title" id="title-field">
-        </div>
-
-        <div class="form-group" id="price-wrapper">
-            <label for="price">Price:</label>
-            <input type="number" name="price" id="price">
-        </div>
+    <div class="form-group" id="price-wrapper">
+      <label for="price">Price:</label>
+      <input type="number" name="price" id="price" step="0.01" value="{{ (job.price if job is defined else '') }}">
     </div>
+  </div>
 </div>
 
-
 <!-- Fumigation Options -->
-<div class="form-section hidden" id="fumigation-section">
-    <h3 class="section-heading">Fumigation Details</h3>
+<div class="form-section {% if jt != 'fumigation' %}hidden{% endif %}" id="fumigation-section">
+  <h3 class="section-heading">Fumigation Details</h3>
+  <div class="form-group">
+    <label><strong>Fumigation Type:</strong></label>
+    <div class="radio-group">
+      <label><input type="radio" name="fumigation_type" value="Tape and Seal"
+        {% if job is defined and job.fumigation_type == 'Tape and Seal' %}checked{% endif %}> Tape &amp; Seal</label>
+      <label><input type="radio" name="fumigation_type" value="Tent"
+        {% if job is defined and job.fumigation_type == 'Tent' %}checked{% endif %}> Tent</label>
+    </div>
+  </div>
 
-        <div class="form-group">
-            <label><strong>Fumigation Type:</strong></label>
-
-            <div class="radio-group">
-                <label><input type="radio" name="fumigation_type" value="Tape and Seal"> Tape & Seal</label>
-                <label><input type="radio" name="fumigation_type" value="Tent"> Tent</label>
-            </div>
-        </div>
-
-        <div class="form-group">
-            <label for="target_pest"><strong>Target Pest:</strong></label>
-            <select name="target_pest" id="target_pest_select" onchange="toggleCustomPestField(this)">
-                <option value="">-- Select a target pest --</option>
-                <option value="Bedbugs">Bedbugs</option>
-                <option value="Powder Post Beetles">Powder Post Beetles</option>
-                <option value="Old House Borers">Old House Borers</option>
-                <option value="Carpenter Ants">Carpenter Ants</option>
-                <option value="Other">Other (please specify)</option>
-            </select>
-            <input type="text" name="custom_pest" id="custom_pest_input" class="hidden" placeholder="Enter custom target">
-        </div>
+  <div class="form-group">
+    <label for="target_pest"><strong>Target Pest:</strong></label>
+    <select name="target_pest" id="target_pest_select">
+      {% set tp = (job.target_pest if job is defined else '') %}
+      <option value="">-- Select a target pest --</option>
+      <option value="Bedbugs"              {% if tp=='Bedbugs' %}selected{% endif %}>Bedbugs</option>
+      <option value="Powder Post Beetles"  {% if tp=='Powder Post Beetles' %}selected{% endif %}>Powder Post Beetles</option>
+      <option value="Old House Borers"     {% if tp=='Old House Borers' %}selected{% endif %}>Old House Borers</option>
+      <option value="Carpenter Ants"       {% if tp=='Carpenter Ants' %}selected{% endif %}>Carpenter Ants</option>
+      <option value="Other"                {% if tp=='Other' %}selected{% endif %}>Other (please specify)</option>
+    </select>
+    <input type="text" name="custom_pest" id="custom_pest_input" class="{% if tp!='Other' %}hidden{% endif %}" placeholder="Enter custom target" value="{{ (job.custom_pest if job is defined else '') }}">
+  </div>
 </div>
 
 <!-- REI Options -->
-<div class="form-section hidden" id="rei-options">
-    <h3 class="section-heading">Reinspections (REIs)</h3>
+<div class="form-section {% if jt != 'rei' %}hidden{% endif %}" id="rei-options">
+  <h3 class="section-heading">Reinspections (REIs)</h3>
 
-    <div class="form-group">
-        <label for="rei_quantity">Quantity</label>
-        <input type="number" id="rei_quantity" name="rei_quantity" min="1" step="1" placeholder="e.g., 12">
-    </div>
+  <div class="form-group">
+    <label for="rei_quantity">Quantity*</label>
+    <input type="number" id="rei_quantity" name="rei_quantity" min="1" step="1"
+           value="{{ (job.rei_quantity if job is defined else '1') }}" required>
+  </div>
 
-    <div class="form-group">
-        <label for="rei_zip">ZIP (5 digits):</label>
-        <input type="text" id="rei_zip" name="rei_zip" maxlength="5" pattern="\d{5}" placeholder="e.g., 90210">
-    </div>
+  <div class="form-group">
+    <label for="rei_zip">ZIP (optional, 5 digits):</label>
+    <input type="text" id="rei_zip" name="rei_zip" maxlength="5" pattern="\d{5}"
+           value="{{ (job.rei_zip if job is defined else '') }}" placeholder="e.g., 90210">
+  </div>
 
-    <p class="hint">City name will auto-populate from ZIP and be stored as <code>rei_city_name</code>.</p>
+  <div class="form-group">
+    <label for="rei_city_name">City (optional):</label>
+    <input type="text" id="rei_city_name" name="rei_city_name"
+           value="{{ (job.rei_city_name if job is defined else '') }}" placeholder="e.g., Roanoke">
+  </div>
+
+  <p class="hint">Provide a ZIP or City (or leave blank). City is auto-derived from ZIP when possible.</p>
 </div>
 
 <!-- Custom Job Type -->
-<div class="form-section hidden" id="custom-type-div">
-    <h3 class="section-heading sm">Custom Type:</h3>
-    <div class="form-group">
-        <label for="custom_type">Custom Type:</label>
-        <input type="text" name="custom_type">
-    </div>
+<div class="form-section {% if jt != 'custom' %}hidden{% endif %}" id="custom-type-div">
+  <h3 class="section-heading sm">Custom Type:</h3>
+  <div class="form-group">
+    <label for="custom_type">Custom Type:</label>
+    <input type="text" name="custom_type" value="{{ (job.custom_type if job is defined else '') }}">
+  </div>
 </div>
 
 <!-- Exclusion Options -->
-<div class="form-section hidden" id="exclusion-options">
-    <h3 class="section-heading">Exclusion Options</h3>
-    <div class="form-group">
-        <label for="exclusion_subtype">Exclusion Type:</label>
-        <select name="exclusion_subtype">
-            <option value="">-- Select Subtype --</option>
-            <option value="Bats">Bats</option>
-            <option value="Birds">Birds</option>
-            <option value="Mice">Mice</option>
-        </select>
-    </div>
+<div class="form-section {% if jt != 'exclusion' %}hidden{% endif %}" id="exclusion-options">
+  <h3 class="section-heading">Exclusion Options</h3>
+  <div class="form-group">
+    <label for="exclusion_subtype">Exclusion Type:</label>
+    <select name="exclusion_subtype">
+      {% set ex = (job.exclusion_subtype if job is defined else '') %}
+      <option value="">-- Select Subtype --</option>
+      <option value="Bats"  {% if ex=='Bats' %}selected{% endif %}>Bats</option>
+      <option value="Birds" {% if ex=='Birds' %}selected{% endif %}>Birds</option>
+      <option value="Mice"  {% if ex=='Mice' %}selected{% endif %}>Mice</option>
+    </select>
+  </div>
 </div>
 
 <!-- Notes -->
 <div class="form-section">
-    <h3 class="section-heading">Notes</h3>
-    <div class="form-group">
-        <label for="notes">Additional Information:</label><br>
-        <textarea name="notes" rows="4" placeholder="Optional site notes or special instructions."></textarea>
-    </div>
+  <h3 class="section-heading">Notes</h3>
+  <div class="form-group">
+    <label for="notes">Additional Information:</label><br>
+    <textarea name="notes" rows="4" placeholder="Optional site notes or special instructions.">{{ (job.notes if job is defined else '') }}</textarea>
+  </div>
 </div>
 
 <script>
 (function () {
-    const sel = document.getElementById('job_type');
-    const rei = document.getElementById('rei_options');
-    const gen = document.getElementById('generic-job-fields');
+  const sel = document.getElementById('job_type');
+  const rei = document.getElementById('rei-options');           // fixed id
+  const gen = document.getElementById('generic-job-fields');
+  const fum = document.getElementById('fumigation-section');
+  const exc = document.getElementById('exclusion-options');
+  const cus = document.getElementById('custom-type-div');
+  const tpSel = document.getElementById('target_pest_select');
+  const customPest = document.getElementById('custom_pest_input');
+  const titleField = document.getElementById('title-field');
+  const priceField = document.getElementById('price');
 
-    function setRequired(scope, on) {
-        if (!scope) return;
-        scope.querySelectorAll('input, select, textarea').forEach(el => {
-            if (on) el.setAttribute('required', 'required');
-            else el.removeAttribute('required');
-        });
-    }
+  function show(el, on) { if (!el) return; el.classList.toggle('hidden', !on); el.style.display = on ? '' : 'none'; }
+  function req(el, on)  { if (!el) return; el.toggleAttribute('required', !!on); }
+  function setRequiredIn(scope, on) {
+    if (!scope) return;
+    scope.querySelectorAll('input, select, textarea').forEach(el => el.toggleAttribute('required', !!on));
+  }
 
-    function toggle() {
-        const isREI = (sel?.value || '').toLowerCase() === 'rei';
-        if (rei) rei.style.display = isREI ? '' : 'none';
-        if (gen) gen.style.display = isREI ? 'none' : '';
-        setRequired(rei, isREI);
-        setRequired(gen, !isREI);
-    }
+  function toggleByType() {
+    const val = (sel?.value || '').toLowerCase();
+    const isREI = (val === 'rei');
+    const isFum = (val === 'fumigation');
+    const isExc = (val === 'exclusion');
+    const isCus = (val === 'custom');
 
-    sel?.addEventListener('change', toggle);
-    toggle(); // init
+    // sections
+    show(rei, isREI);
+    show(fum, isFum);
+    show(exc, isExc);
+    show(cus, isCus);
+
+    // REI: hide/disable generic fields; require quantity only
+    show(gen, !isREI);
+    if (titleField) titleField.disabled = isREI;
+    if (priceField) priceField.disabled = isREI;
+
+    // client-side requireds (server remains source of truth)
+    setRequiredIn(gen, !isREI);                 // require Job Name for non-REI
+    req(titleField, !isREI);
+    // Price is optional always; do not require
+
+    // Quantity required only for REI
+    const qty = document.getElementById('rei_quantity');
+    req(qty, isREI);
+  }
+
+  function toggleCustomPest() {
+    const v = (tpSel?.value || '');
+    show(customPest, v === 'Other');
+  }
+
+  sel?.addEventListener('change', toggleByType);
+  tpSel?.addEventListener('change', toggleCustomPest);
+
+  // init
+  toggleByType();
+  toggleCustomPest();
 })();
 </script>

--- a/templates/day.html
+++ b/templates/day.html
@@ -36,16 +36,17 @@
 <div style="max-width: 700px; margin: 0 auto;">
   {% for job in jobs %}
   <div class="card">
-    {# one label to rule them all #}
+    {% set jt = (job.job_type or job.type or '')|lower %}
     {% set tech_label = 'Two Man' if job.two_man else (job.technician_name or 'Unassigned') %}
 
-    {# REIs vs everything else #}
-    {% if job.type and job.type|lower in ['rei', 'reis'] %}
+    {% if jt in ['rei','reis'] %}
       <h3 class="job-heading">REIs</h3>
 
       <p class="job-meta">
-        📋 REIs: <strong>{{ job.rei_quantity or "?" }}</strong>
-        {% if job.rei_city_name %} in {{ job.rei_city_name }}{% endif %}
+        REIs: <strong>{{ job.rei_quantity or "?" }}</strong>
+        {% if job.rei_city_name %} in {{ job.rei_city_name }}
+        {% elif job.rei_zip %} (ZIP {{ job.rei_zip }})
+        {% endif %}
       </p>
 
       {% if job.two_man or job.technician_name %}
@@ -55,26 +56,24 @@
       <h3 class="job-heading">{{ job.display_title or job.title or "(Untitled)" }}</h3>
 
       {% if job.price %}
-        <p class="job-meta">💵 ${{ "%.2f"|format(job.price) }}</p>
+        <p class="job-meta">${{ "%.2f"|format(job.price) }}</p>
       {% endif %}
 
-      {% if job.time_range and job.time_range != "" %}
+      {% if job.time_range or (job.start_time and job.end_time) %}
         <p class="job-meta">
-          🕒 {{ job.time_range or (job.start_time ~ '-' ~ job.end_time if job.start_time and job.end_time else '') }}
+          🕒 {{ job.time_range or (job.start_time ~ '-' ~ job.end_time) }}
         </p>
       {% endif %}
 
-      {% if job.type %}
-        <p class="job-meta">
-          🏷️ Type:
-          <strong>{{ 'rei' if job.type and (job.type|lower in ['rei','reis']) else job.type }}</strong>
-        </p>
+      {% if jt %}
+        <p class="job-meta">Type: <strong>{{ jt }}</strong></p>
       {% endif %}
 
       {% if job.two_man or job.technician_name %}
         <p class="job-meta job-meta-light">🔧 {{ tech_label }}</p>
       {% endif %}
     {% endif %}
+
 
     {% if job.notes %}
       <p class="job-notes">📝 {{ job.notes }}</p>
@@ -117,24 +116,32 @@
   </div>
   {% endfor %}
 
-  {# OFF cards (after jobs) #}
-  {% if time_off_names %}
-    {% for name in time_off_names %}
+{% if time_off %}
+  {% for to in time_off %}
     <div class="card off-card">
       <div class="job-header">
         <span class="job-tag">OFF</span>
-        <span class="job-title">{{ name }}</span>
+        <span class="job-title">{{ to.tech_name or 'Unknown Tech' }}</span>
       </div>
       <div class="job-footer">
-        <span class="job-meta-light">Unavailable all day</span>
+        <span class="job-meta-light">
+          Unavailable all day{% if to.reason %} • {{ to.reason }}{% endif %}
+        </span>
+
+        {% if not locked and session.get("user") %}
+          <form method="POST"
+                action="{{ url_for('job.timeoff_delete', timeoff_id=to.id) }}"
+                class="inline"
+                onsubmit="return confirm('Remove this time off?');">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-red btn-sm">🗑 Remove</button>
+          </form>
+        {% endif %}
       </div>
     </div>
-    {% endfor %}
-  {% endif %}
-</div>
-{% else %}
-<p class="text-center" style="color: #888">No jobs scheduled for this day.</p>
+  {% endfor %}
 {% endif %}
+
 
 <!-- Move Modal -->
 <div id="moveModal" class="modal">

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
 
 {% if session.get("user") %}
 <div class="calendar-actions">
-    <a href="{{ url_for('job.add_job', date=today.isoformat()) }}" class="btn btn-yellow">
+    <a href="{{ url_for('job.add_job_for_date', date=today.isoformat()) }}" class="btn btn-yellow">
         + Add Job
     </a>
     <a href="{{ url_for('calendar.add_time_off') }}" class="btn btn-yellow">+ Add Time Off
@@ -65,89 +65,79 @@
             {% endif %}
 
             <div class="jobs">
-                {% if time_off_by_date.get(day_str) %}
-                    {% for tech_name in time_off_by_date[day_str] %}
-
-                    <div class="job-entry off-entry" title="{{ tech_name }} is off">
-                        <div class="job-header">
-                            <span class="job-tag">OFF</span>
-                            <span class="job-title">{{ tech_name.split()[0][0] }}.{{ tech_name.split()[1] }}</span>
-                        </div>
+  {# Time Off pills (names only) #}
+              {% if time_off_by_date.get(day_str) %}
+                {% for tech_name in time_off_by_date[day_str] %}
+                  <div class="job-entry off-entry" title="{{ tech_name }} is off">
+                    <div class="job-header">
+                      <span class="job-tag">OFF</span>
+                      {# initials + last name fallback #}
+                      {% set parts = (tech_name or '').split() %}
+                      {% set short = (parts[0][0] ~ '.' ~ (parts[1] if parts|length>1 else '')) if parts|length>=1 else tech_name %}
+                      <span class="job-title">{{ short }}</span>
                     </div>
-
-                    {% endfor %}
-                {% endif %}
-                    {% for job in (jobs_by_date.get(day_str, []) | sort
-                    (attribute='time_range')) %}
-                    {# BUG-1006: template expects 'rei' but code uses 'reis'. Normalize: #}
-                    {% set job_type_clean = (job.type or job.job_type or "")|lower|trim %}
-                    {% if job_type_clean in ["rei","reis"] %}
-
-                    {% if job.two_man %}
-                        {% set tech_display = 'Two Men' %}
-                    {% else %}
-                        {% set tech_parts = (job.technician_name or "").split(" ") %}
-                        {% set tech_display = tech_parts[0][0] ~ "." ~ tech_parts[1] if tech_parts | length > 1 else (job.technician_name or "") %}
-                    {% endif %}
-
-                    <div class="job-entry rei-entry" title="Reinspection">
-                        <div class="job-header job-info-flex">
-                            <div class="job-left">
-                                <span class="job-tag">REIs</span>
-                                <span class="job-qty">{{ job.rei_quantity }}</span>
-                                {% if job.rei_city_name or job.rei_zip %}
-                                    <span class="job-city">{{ job.rei_city_name or job.rei_zip }}</span>
-                                {% endif %}
-                            </div>
-                        </div>
-
-                        {% if tech_display %}
-                        <div class="job-footer">
-                            <span class="job-title">{{ tech_display }}</span>
-                        </div>
-                        {% endif %}
-                    </div>
-
-                    {# removed stray </div> that prematurely closed jobs-wrapper #}
-                    {% else %}
-                        {% set job_type_clean = (job.type or "")|lower|trim %}
-                        {% set type_abbrv = (type_abbr|default).get(job_type_clean, (job_type_clean[:1])|upper) %}
-                        {% set display_name = job.title or "Unknown" %}
-                        {% set price = job.price %}
-                        {% set is_first_day = (day_str == job.start_date) %}
-                        {% set is_last_day = (day_str == job.end_date) %}
-                        {% set is_multi_day = job.start_date != job.end_date %}
-
-                        {% set cont_left = is_multi_day and not is_first_day %}
-                        {% set cont_right = is_multi_day and not is_last_day %}
-                        {% set show_price = is_first_day %}
-
-                    <div class="job-entry" {{ 'continues-left' if cont_left}} {{ 'continues-right' if cont_right}} title="{{ display_name }}">
-                        <div class="job-header">
-                            {% set _display_time = job.time_range if job.time_range and job.time_range != 'any'
-                                else (job.start_time ~ '-' ~ job.end_time if job.start_time and job.end_time else None) %}
-                            {% if _display_time %}
-                                <span class="job-time">{{ _display_time }}</span>
-                            {% endif %}
-                            <span class="job-tag">{{ type_abbrv }}</span>
-                            <span class="job-title">{{ display_name }}</span>
-                        </div>
-                        {% set tech_label = 'Two Men' if job.two_man else (job.technician_name or '') %}
-                        <div class="job-footer">
-                            {% if tech_label %}
-                                <span class="job-tech">{{ tech_label }}</span>
-                            {% endif %}
-                            {% if show_price and price not in [None, '', 0] %}
-                                <span class="job-price">${{ ("%0.2f"|format(price|float)).rstrip('0').rstrip('.') }}</span>
-                            {% else %}
-                                <span class="job-price tbd">TBD</span>
-                            {% endif %}
-                            {% if cont_left %}<span class="job-arrow job-arrow-left">⟵</span>{% endif %}
-                            {% if cont_right %}<span class="job-arrow job-arrow-right">⟶</span>{% endif %}
-                            {% endif %}
-                        </div>
-                    </div>
+                  </div>
                 {% endfor %}
+              {% endif %}
+
+              {# Jobs, sorted by time_range #}
+              {% for job in (jobs_by_date.get(day_str, []) | sort(attribute='time_range')) %}
+                {% set jt = (job.job_type or job.type or '')|lower %}
+                {% if jt in ['rei','reis'] %}
+                  {# REI tile #}
+                  <div class="job-entry rei-entry" title="Reinspection">
+                    <div class="job-header job-info-flex">
+                      <div class="job-left">
+                        <span class="job-tag">REIs</span>
+                        <span class="job-qty">{{ job.rei_quantity or 0 }}</span>
+                        {% if job.rei_city_name or job.rei_zip %}
+                          <span class="job-city">{{ job.rei_city_name or job.rei_zip }}</span>
+                        {% endif %}
+                      </div>
+                    </div>
+                    {% set tech_display = 'Two Men' if job.two_man else (job.technician_name or '') %}
+                    {% if tech_display %}
+                      <div class="job-footer">
+                        <span class="job-title">{{ tech_display }}</span>
+                      </div>
+                    {% endif %}
+                  </div>
+                {% else %}
+                  {# Generic job tile with multiday continuation markers #}
+                  {% set display_name  = job.title or "Unknown" %}
+                  {% set price         = job.price %}
+                  {% set is_first_day  = (day_str == job.start_date) %}
+                  {% set is_last_day   = (day_str == job.end_date) %}
+                  {% set is_multi_day  = job.start_date and job.end_date and (job.start_date != job.end_date) %}
+                  {% set cont_left     = is_multi_day and not is_first_day %}
+                  {% set cont_right    = is_multi_day and not is_last_day %}
+                  {% set _display_time = job.time_range if job.time_range and job.time_range != 'any'
+                                          else (job.start_time ~ '-' ~ job.end_time if job.start_time and job.end_time else None) %}
+                  {% set jtc = jt %}
+                  {% set type_abbrv = (type_abbr|default({})).get(jtc, (jtc[:1]|upper) if jtc else '?') %}
+                  {% set tech_label = 'Two Men' if job.two_man else (job.technician_name or '') %}
+
+                  <div class="job-entry {% if cont_left %}continues-left{% endif %} {% if cont_right %}continues-right{% endif %}" title="{{ display_name }}">
+                    <div class="job-header">
+                      {% if _display_time %}<span class="job-time">{{ _display_time }}</span>{% endif %}
+                      <span class="job-tag">{{ type_abbrv }}</span>
+                      <span class="job-title">{{ display_name }}</span>
+                    </div>
+                    <div class="job-footer">
+                      {% if tech_label %}<span class="job-tech">{{ tech_label }}</span>{% endif %}
+                      {% if is_first_day and price not in [None, '', 0] %}
+                        <span class="job-price">
+                          ${{ ("%0.2f"|format(price|float)).rstrip('0').rstrip('.') }}
+                        </span>
+                      {% else %}
+                        <span class="job-price tbd">TBD</span>
+                      {% endif %}
+                      {% if cont_left %}<span class="job-arrow job-arrow-left">⟵</span>{% endif %}
+                      {% if cont_right %}<span class="job-arrow job-arrow-right">⟶</span>{% endif %}
+                    </div>
+                  </div>
+                {% endif %}
+              {% endfor %}
             </div>
         </td>
         {% endfor %}

--- a/utils/version.py
+++ b/utils/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.3.0-dev"
+__version__ = "0.3.1-dev"


### PR DESCRIPTION
## Summary

This PR fixes three critical scheduling issues and adds time-off CRUD:

1) REI creation UX and server semantics
   - Hide Job Name/Price for REIs; require quantity only
   - Accept ZIP or City (ZIP->City auto-resolves)
   - Normalize 'rei' vs 'reis' across templates
2) Time off management
   - Add `POST /timeoff/add` and `POST /TIMEOFF/delete/<id>`
   - Day view shows OFF cards with remove button (RBAC)
3) Month view edge-days
   - Query by visible grid range (Sun-start); jobs/time-off that overlap
   - Expand and clamp multi-day jobs to per-day buckets
   - Multiday continuation markers; price on first day
   
## Files Touched
   - routes/job_routes.py: timeoff_add/delete
   - routes/calendar_routes.py: index() grid window; day_view() returns `time_off`; lock toggle user id fallback
   - templates/_job_fields.html: REI-only fields + JS toggles
   - templates/day.html: REI normalization; OFF removal UI; markup fixes
   - templates/index.html: edge-day jobs, REI tiles, initials for OFF, +Add Job link
   - db.py: indexes for overlap queries